### PR TITLE
fix recent flutter version compatibility issue

### DIFF
--- a/lib/slide_to_act.dart
+++ b/lib/slide_to_act.dart
@@ -123,7 +123,7 @@ class SlideActionState extends State<SlideAction>
                     transform: Matrix4.rotationY(widget.reversed ? pi : 0),
                     child: Center(
                       child: Stack(
-                        overflow: Overflow.clip,
+                        clipBehavior: Clip.antiAlias,
                         children: <Widget>[
                           widget.submittedIcon ??
                               Icon(
@@ -149,7 +149,7 @@ class SlideActionState extends State<SlideAction>
                   )
                 : Stack(
                     alignment: Alignment.center,
-                    overflow: Overflow.visible,
+                    clipBehavior: Clip.none,
                     children: <Widget>[
                       Opacity(
                         opacity: 1 - 1 * _progress,


### PR DESCRIPTION
Fix the breaking change introduced by https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea and merged into flutter master by https://github.com/flutter/flutter/pull/61366 by replacing `overflow: Overflow.visible,` with `clipBehavior: Clip.none,` in the Stack object instantiation.

Fixes #1.