### PR TITLE
replace accentColor with colorScheme.secondary

### DIFF
--- a/lib/slide_to_act.dart
+++ b/lib/slide_to_act.dart
@@ -125,7 +125,7 @@ class SlideActionState extends State<SlideAction>
               : BoxConstraints.expand(height: widget.height),
           child: Material(
             elevation: widget.elevation,
-            color: widget.outerColor ?? Theme.of(context).accentColor,
+            color: widget.outerColor ?? Theme.of(context).colorScheme.secondary,
             borderRadius: BorderRadius.circular(widget.borderRadius),
             child: submitted
                 ? Transform(
@@ -149,7 +149,7 @@ class SlideActionState extends State<SlideAction>
                               alignment: Alignment.centerRight,
                               child: Container(
                                 color: widget.outerColor ??
-                                    Theme.of(context).accentColor,
+                                    Theme.of(context).colorScheme.secondary,
                               ),
                             ),
                           ),
@@ -229,7 +229,7 @@ class SlideActionState extends State<SlideAction>
                                                     widget.sliderButtonIconSize,
                                                 color: widget.outerColor ??
                                                     Theme.of(context)
-                                                        .accentColor,
+                                                        .colorScheme.secondary,
                                               ),
                                         ),
                                       ),


### PR DESCRIPTION
accentColor does not exist anymore in the recent flutter version, it can be replaced by ColorScheme.secondary as stated here: https://docs.flutter.dev/release/breaking-changes/theme-data-accent-properties#accentcolor